### PR TITLE
Detect moderation levels

### DIFF
--- a/StreetTagged/AWS/ImageManagement.swift
+++ b/StreetTagged/AWS/ImageManagement.swift
@@ -64,3 +64,16 @@ func fixOrientation(img:UIImage) -> UIImage {
   return normalizedImage;
 
 }
+
+
+func getModerationTags(params:String) -> String {
+    let moderationParameters = {
+        
+            "bucket": "streetartprod",
+            "name": "2549f47b-4ed4-4fcd-a7ed-712bddfd7bc6-56AB1578-0A5F-444A-B8ED-5C50410FD770.jpg"
+        
+        
+    }
+    
+    print(moderationParameters)
+}

--- a/StreetTagged/AWS/ImageManagement.swift
+++ b/StreetTagged/AWS/ImageManagement.swift
@@ -64,5 +64,3 @@ func fixOrientation(img:UIImage) -> UIImage {
   return normalizedImage;
 
 }
-
-

--- a/StreetTagged/AWS/ImageManagement.swift
+++ b/StreetTagged/AWS/ImageManagement.swift
@@ -66,14 +66,3 @@ func fixOrientation(img:UIImage) -> UIImage {
 }
 
 
-func getModerationTags(params:String) -> String {
-    let moderationParameters = {
-        
-            "bucket": "streetartprod",
-            "name": "2549f47b-4ed4-4fcd-a7ed-712bddfd7bc6-56AB1578-0A5F-444A-B8ED-5C50410FD770.jpg"
-        
-        
-    }
-    
-    print(moderationParameters)
-}

--- a/StreetTagged/Globals.swift
+++ b/StreetTagged/Globals.swift
@@ -58,6 +58,10 @@ let GLOBAL_NEED_SIGN_UP = "GLOBAL_NEED_SIGN_UP"
 let GLOBAL_CDN = "images.streettagged.com"
 
 let searchURL = UIApplication.appAPIURL! + "/items/search"
+
+let postItemURL = UIApplication.appAPIURL! + "/items"
+let moderationTagsURL = UIApplication.appAPIURL! + "/tags/moderation"
+let tagsURL = UIApplication.appAPIURL! + "/tags"
 let postItemURL = UIApplication.appAPIURL! + "/items"
 let urlFavorite = UIApplication.appAPIURL! + "/favorites"
 let getItemURL = UIApplication.appAPIURL! + "/items"

--- a/StreetTagged/Globals.swift
+++ b/StreetTagged/Globals.swift
@@ -62,9 +62,9 @@ let searchURL = UIApplication.appAPIURL! + "/items/search"
 let postItemURL = UIApplication.appAPIURL! + "/items"
 let moderationTagsURL = UIApplication.appAPIURL! + "/tags/moderation"
 let tagsURL = UIApplication.appAPIURL! + "/tags"
-let postItemURL = UIApplication.appAPIURL! + "/items"
 let urlFavorite = UIApplication.appAPIURL! + "/favorites"
 let getItemURL = UIApplication.appAPIURL! + "/items"
+let s3Bucket = "streetartprod"
 
 func imageURLFromS3Key(key: String, filter: String) -> String {
     return "https://" + GLOBAL_CDN + "/" + filter + "/" + key

--- a/StreetTagged/ViewControllers/Controllers/UploadArtController.swift
+++ b/StreetTagged/ViewControllers/Controllers/UploadArtController.swift
@@ -26,9 +26,12 @@ public class UploadArtController: UIViewController, UIImagePickerControllerDeleg
     
     var imageLink = ""
     var tags: [String] = []
+    var tags: [String] = []
     let center = UNUserNotificationCenter.current()
     
     var hasImage: Bool = false
+    var hasModerationTags: Bool = false
+
     var timer = Timer()
     
     let regionRadius: CLLocationDistance = 1000
@@ -55,6 +58,8 @@ public class UploadArtController: UIViewController, UIImagePickerControllerDeleg
                 let about: String = self.textView.text!
                 getUserAWSAccessToken (completionHandler: { (token) in
                     var coordinates: [String : Any]?
+                    
+                    //if moderation tags = null, seet is active to true
                     if self.imageLocation != nil {
                         coordinates = [
                             "latitude": self.imageLocation!.coordinate.latitude,
@@ -104,7 +109,7 @@ public class UploadArtController: UIViewController, UIImagePickerControllerDeleg
     }
     
     @objc func timerAction() {
-        if (self.hasImage == true && hasGlobalGPS == true && self.progressBar.progress == 1.0) {
+        if (self.hasImage == true && hasGlobalGPS == true && self.hasModerationTags && self.progressBar.progress == 1.0) {
             navigationItem.rightBarButtonItem?.isEnabled = true;
         }
         if (self.progressBar.progress == 1.0) {
@@ -138,11 +143,15 @@ public class UploadArtController: UIViewController, UIImagePickerControllerDeleg
                         self.imageLink = imageURL
                         self.hasImage = true
                         print(imageURL)
+                        //moderate image
+                            // if passes
+                        self.hasModerationTags = true
+                        
                     }
                 }
             })
         }
-                
+        
         textView.becomeFirstResponder()
         
         if self.imageLocation != nil {

--- a/StreetTagged/ViewControllers/Controllers/UploadArtController.swift
+++ b/StreetTagged/ViewControllers/Controllers/UploadArtController.swift
@@ -96,6 +96,7 @@ public class UploadArtController: UIViewController, UIImagePickerControllerDeleg
                                 self.dismiss(animated: true, completion: nil)
                             }))
                             self.present(alert, animated: true, completion: nil)
+                            refreshPosts()
                             
                         }
                         
@@ -132,7 +133,7 @@ public class UploadArtController: UIViewController, UIImagePickerControllerDeleg
             let modParameters: [String : Any] = [
                 "bucket": s3Bucket,
                 "name": imageFilename
-                //"name": "1840_burnt-orange2.jpg"
+                //"name": "1840_burnt-orange2.jpg"  //use this line to force a moderation label
             ]
             
             

--- a/StreetTagged/ViewControllers/Controllers/ViewController.swift
+++ b/StreetTagged/ViewControllers/Controllers/ViewController.swift
@@ -35,6 +35,16 @@ struct ArtWorks: Decodable {
     let items: [Art]
 }
 
+struct ModerationLabel: Decodable {
+    let Confidence: Double
+    let Name: String
+    let ParentName: String
+}
+
+struct ModerationLabels: Decodable {
+    let data: [ModerationLabel]
+ }
+
 struct FavoriteArtWorks: Decodable {
     let artWorks: [Art]
 }


### PR DESCRIPTION
Upload controller now hits a moderation endpoint after upload to detect an unsafe images.

If unsafe images are detected, it prompts user that further verification is required.

If image passes Amazon Rekognition test, it gets automatically posted and available on refresh.